### PR TITLE
Updated for metadata for support with 3.18

### DIFF
--- a/icon-hider@kalnitsky.org/metadata.json
+++ b/icon-hider@kalnitsky.org/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.10", "3.12", "3.14", "3.16"],
+    "shell-version": ["3.10", "3.12", "3.14", "3.16", "3.18"],
     "uuid": "icon-hider@kalnitsky.org",
     "name": "Icon Hider",
     "description": "Show/Hide icons from top panel",


### PR DESCRIPTION
I have tested this extension with 3.18 in Arch Linux and the extension works as expected. I think it is safe to merge and update on the main EGO (extensions.gnome.org) page.